### PR TITLE
persist speedtest log and schedule and improve scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Install (or reinstall) the latest version of the Mod and only the Mod. For infor
 <details>
 <summary><strong>Via the Shell</strong></summary>
 
-You can just pipe to bash (inside the Docker container, if you're using it).
+You can just pipe to bash (inside the Docker container, if you're using it (after every rebuild (use Compose))).
 
 ```bash
 curl -sSLN https://github.com/arevindh/pi-hole/raw/master/advanced/Scripts/speedtestmod/mod.sh | sudo bash
@@ -141,7 +141,7 @@ build:
 
 ### v2.2.1
 
-Feb 13 2024 - [Persist speedtest log](https://github.com/arevindh/pihole-speedtest/pull/159)
+Feb 17 2024 - [Installation and Testing Enchancements](https://github.com/arevindh/pihole-speedtest/pull/159)
 
 <details>
 <summary><strong>Older</strong></summary>

--- a/README.md
+++ b/README.md
@@ -139,12 +139,16 @@ build:
 
 ## Release Notes
 
-### v2.2
+### v2.2.1
 
-Feb 13 2024 - [Docker and Fedora Support](https://github.com/arevindh/pihole-speedtest/pull/157)
+Feb 13 2024 - [Persist speedtest log](https://github.com/arevindh/pihole-speedtest/pull/159)
 
 <details>
 <summary><strong>Older</strong></summary>
+
+### v2.2
+
+Feb 13 2024 - [Docker and Fedora Support](https://github.com/arevindh/pihole-speedtest/pull/157)
 
 ### v2.1
 


### PR DESCRIPTION
This is a patch to persist the speedtest log and schedule.

Related PRs:
* arevindh/pi-hole#75
* arevindh/AdminLTE#87

Fixes:
* Resetting the schedule
* Detached head

Enhancements:
* Health check shows the latest speedtest even after a rebuild
* Try test thrice